### PR TITLE
Renovate と Dependabot の auto-merge 設定を追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge --auto --merge --repo "$GH_REPO" "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,46 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "automergeStrategy": "merge-commit",
+  "packageRules": [
+    {
+      "description": "テスト用 Go モジュールの minor/patch は automerge",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "matchPackageNames": [
+        "gotest.tools/v3",
+        "github.com/google/go-cmp",
+        "github.com/stretchr/testify"
+      ]
+    },
+    {
+      "description": "信頼できる GitHub Actions の minor/patch/digest は automerge",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-go",
+        "codecov/codecov-action",
+        "Kesin11/actions-timeline",
+        "release-drafter/release-drafter",
+        "ruby/setup-ruby"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## 概要

Renovate / Dependabot がどちらも稼働していますが、auto-merge が一切設定されておらず、依存更新 PR が手動マージ待ちで滞留しています。kaki-org/baukis2・kaki-org/taskleaf と同じ方針で auto-merge を設定します。

## 変更内容

### `renovate.json`
- テスト用 Go モジュール（`gotest.tools/v3` / `go-cmp` / `testify`）の `minor` / `patch` 更新を automerge
- 本リポジトリで実際に使用している GitHub Actions の `minor` / `patch` / `digest` 更新を automerge
- `automergeStrategy: merge-commit` を指定

`gin` / `gorm` / `golang-jwt` / `golang.org/x/crypto` などの実行時依存は許可リストに含めず、従来どおり手動マージのままとしています。

### `.github/workflows/dependabot-auto-merge.yml`（新規）
- Dependabot の PR に GitHub の auto-merge を有効化する
- `dependabot/fetch-metadata` で更新種別を判定し、`version-update:semver-major` は auto-merge しない

## 前提: branch protection

auto-merge は「マージ可能になった時点で自動マージ」する機能のため、required status checks が無いと CI 完了を待たずに即マージされます。そのため本 PR とは別に、`main` ブランチへ以下を設定済みです。

- required status checks: `build`
- strict（base への追従必須）は無効
- required approving reviews は 0 件（レビュー必須にすると auto-merge が永久に待機するため）

## 補足 / 別途対応が必要な点

- **`.github/workflows/go.yml` と `.github/workflows/build.yml` が実質同一の重複ワークフローです。** どちらも `name: Go Package` / job 名 `build` で、1 つの PR に対して同名の `build` チェックが 2 つ生成されます。required status check としては動作しますが紛らわしいため、どちらかへの統合を別途検討したほうがよいです。本 PR のスコープ外としています。
- **Renovate と Dependabot が両方 `gomod` / `github-actions` を見ています。** 同じ更新 PR が両方の bot から重複して作られる状態です。どちらか一方に寄せる整理は本 PR のスコープ外としています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated maintenance updates can now be merged more efficiently when they meet predefined safety criteria.
  * Major version updates remain subject to additional review before merging.
  * Trusted tooling updates may be applied automatically for minor, patch, and compatible revision changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->